### PR TITLE
checking asset catalog if +[SUBundleIcon iconURLForHost:] returns nil

### DIFF
--- a/Sparkle/SUApplicationInfo.m
+++ b/Sparkle/SUApplicationInfo.m
@@ -21,7 +21,19 @@
 {
     NSURL *iconURL = [SUBundleIcon iconURLForHost:host];
     
-    NSImage *icon = (iconURL == nil) ? nil : [[NSImage alloc] initWithContentsOfURL:iconURL];
+    NSImage *icon = nil;
+    if (iconURL != nil) {
+        icon = [[NSImage alloc] initWithContentsOfURL:iconURL];
+    }
+    
+    if (!icon) {
+        // Apps linked against 10.13 or newer SDK can use app icon directly from asset catalog (see CFBundleIconName)
+        NSString *const iconAssetName = [SUBundleIcon iconAssetNameForHost:host];
+        if (iconAssetName != nil) {
+            icon = [NSImage imageNamed:iconAssetName];
+        }
+    }
+    
     // Use a default icon if none is defined.
     if (!icon) {
         // this asumption may not be correct (eg. even though we're not the main bundle, it could be still be a regular app)

--- a/Sparkle/SUBundleIcon.h
+++ b/Sparkle/SUBundleIcon.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSURL * _Nullable)iconURLForHost:(SUHost *)host;
 
++ (NSString * _Nullable)iconAssetNameForHost:(SUHost *)host;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SUBundleIcon.m
+++ b/Sparkle/SUBundleIcon.m
@@ -31,4 +31,13 @@
     return iconURL;
 }
 
++ (NSString *)iconAssetNameForHost:(SUHost *)host
+{
+    NSString *const name = [host objectForInfoDictionaryKey:@"CFBundleIconName"];
+    if (name == nil || ![name isKindOfClass:[NSString class]]) {
+        return nil;
+    }
+    return name;
+}
+
 @end


### PR DESCRIPTION
после дропа 10.12 спаркл в эксперте перестал показывать нашу иконку в своем UI. оказалось, что в 10.13 больше не создается AppIcon.icns, т.к. система берет иконку прямо из каталога ассетов. спаркл этого делать не умел, земля ему стекловатой. теперь умеет 
@asavkov может вам тоже будет полезно